### PR TITLE
Introduce new plugin property `lookup_groups_base`. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+*.egg
+*.egg-info
+*.mo
+*.pyc
+.installed.cfg
+.installed.cfg
+.mr.developer.cfg
+bin/
+build/
+buildout.cfg
+coverage/
+develop-eggs/
+develop-eggs/
+dist/
+parts/
+src/
+var/

--- a/Products/LDAPMultiPlugins/README.txt
+++ b/Products/LDAPMultiPlugins/README.txt
@@ -9,6 +9,17 @@ the backend for the services they provide. The PluggableAuthService is a
 Zope user folder product that can be extended in modular fashion using 
 various plugins.
 
+Customizations:
+===============
+
+This fork contains the following customizations:
+
+Lookup groups base DN
+---------------------
+
+The optional property `lookup_groups_base` allows to use different base DNs for group lookups than for group enumeration.
+If the plugin_property `lookup_groups_base` is defined, the plugin will use the DN defined in `lookup_groups_base` for group lookups (`getGroupsForPrincipal`), but the group enumeration ('enumerateGroups`) still uses the DN defined in the property `groups_base`.
+
 
 Bug tracker
 ===========

--- a/README.txt
+++ b/README.txt
@@ -1,1 +1,5 @@
+===============================================================
+Fork of https://www.netz.ooo/git/Products.LDAPMultiPlugins.git
+===============================================================
+
 (see Products/LDAPMultiPlugins/README.txt)


### PR DESCRIPTION
An additional possibility to define a separate groups base_dn for the group lookup.
This allow us to set a restricted groups_base, which does not include all nested groups. Because the plugin considers now also group memberships outside the restricted groups_base and uses the `lookup_groups_base` property if it exists.

