### PR TITLE
Handle CNs with commas in them in group membership resolution

### DIFF
--- a/Products/LDAPMultiPlugins/README.txt
+++ b/Products/LDAPMultiPlugins/README.txt
@@ -20,6 +20,11 @@ Lookup groups base DN
 The optional property `lookup_groups_base` allows to use different base DNs for group lookups than for group enumeration.
 If the plugin_property `lookup_groups_base` is defined, the plugin will use the DN defined in `lookup_groups_base` for group lookups (`getGroupsForPrincipal`), but the group enumeration ('enumerateGroups`) still uses the DN defined in the property `groups_base`.
 
+Support for commas in group CNs
+-------------------------------
+
+If a group CN contains a comma, some special care is taken to make group membership resolution work.
+
 
 Bug tracker
 ===========

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -7,8 +7,11 @@
 1.15.post2 (2017-08-08)
 -----------------------
 
-- Nothing changed yet.
+- Filter group names that contain non-ascii characters. [buchi]
+- Return only groups contained in groups base DN. [buchi]
 
 
 1.15.post1 (2017-07-12)
 -----------------------
+
+- Introduce new plugin property `lookup_groups_base`. [phgross]

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,7 +1,7 @@
 1.15.post3 (unreleased)
 -----------------------
 
-- Nothing changed yet.
+- Handle CNs with commas in them in group membership resolution. [lgraf]
 
 
 1.15.post2 (2017-08-08)


### PR DESCRIPTION
Handle CNs with commas in them in group membership resolution:

When splitting DNs on commas in `getGroupsForPrincipal()` we need to take care to mask commas that are part of CNs beforehand, and unmask them again after splitting.

In addition, it seems that either `delegate.search()` (or possibly the Python `ldap` module) already handles proper escaping of commas in CNs when used in _filters_. This means that in order to filter for a CN containing a comma, the comma in the CN should just be included verbatim, *without* any blackslash before the comma.

We therefore remove the backslash as well when unmasking.